### PR TITLE
Add crude version of method MoveGhost() in Board.cs

### DIFF
--- a/EightTeenGhosts/Board.cs
+++ b/EightTeenGhosts/Board.cs
@@ -27,6 +27,9 @@ namespace EightTeenGhosts
             // Place the rest of the pieces
             SetMirrors();
             SetPortals();
+            SetGhost();
+            MoveGhost(0, 0, 1, 0);
+            MoveGhost(1, 0, 2, 0);
         }
 
         private void SetMirrors()
@@ -47,6 +50,12 @@ namespace EightTeenGhosts
             boardState[2, 4].Color = CellColor.Yellow;
             boardState[4, 2].Type = CellType.Portal;
             boardState[4, 2].Color = CellColor.Blue;
+        }
+
+        private void SetGhost()
+        {
+            boardState[0, 0].Type = CellType.Ghost;
+            boardState[0, 0].Color = CellColor.Blue;
         }
 
         private void SetBlanks()
@@ -101,6 +110,20 @@ namespace EightTeenGhosts
                         boardState[i, j].Color = CellColor.Blue;
                 }
             }
+        }
+
+        CellColor previousColor1;
+        CellColor previousColor2;
+
+        public void MoveGhost(int xI, int yI, int xF, int yF)
+        {
+            previousColor1 = boardState[xI, yI].Color;
+            previousColor2 = boardState[xF, yF].Color;
+            boardState[xI, yI].Type = CellType.Empty;
+            boardState[xF, yF].Type = CellType.Ghost;
+            boardState[xI, yI].Color = previousColor1;
+            previousColor1 = boardState[xF, yF].Color;
+            boardState[xF, yF].Color = previousColor2;
         }
     }
 }

--- a/EightTeenGhosts/Renderer.cs
+++ b/EightTeenGhosts/Renderer.cs
@@ -51,6 +51,9 @@ namespace EightTeenGhosts
                         case (CellType.Portal):
                             PrintPortals(color, j);
                             break;
+                        case (CellType.Ghost):
+                            PrintGhosts(color, j);
+                            break;
                     }
                     
                 }
@@ -152,6 +155,42 @@ namespace EightTeenGhosts
             // Writes the representative char and closes the cell row
             // accordingly
             Console.Write($"{emptyState}");
+            Console.ResetColor();
+            if (column == 4)
+                Console.Write($"  |");
+            else
+                Console.Write($"  ");
+        }
+
+        private static void PrintGhosts(CellColor color, int column)
+        {
+            // Writes the first character for the middle row of a cell
+            Console.Write($"|  ");
+
+            // Checks the color of the cell and changes foreground for the 
+            // said color
+            switch (color)
+            {
+                case (CellColor.Red):
+                    {
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        break;
+                    }
+                case (CellColor.Yellow):
+                    {
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        break;
+                    }
+                case (CellColor.Blue):
+                    {
+                        Console.ForegroundColor = ConsoleColor.Blue;
+                        break;
+                    }
+            }
+
+            // Writes the representative char and closes the cell row
+            // accordingly
+            Console.Write($"G");
             Console.ResetColor();
             if (column == 4)
                 Console.Write($"  |");


### PR DESCRIPTION
Add necessary methods to place a ghost and print it (SetGhost() in Board.cs and PrintGhosts() in Renderer.cs
Keeps colors of the previus cells, but the color of the ghost is wrong
